### PR TITLE
Make SSH host configurable (default: ssh.pythonanywhere.com)

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,4 +1,3 @@
-
 name: Deploy to PythonAnywhere
 
 on:
@@ -12,10 +11,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Redeploy to PythonAnywhere
-        uses: MiguelRizzi/pythonanywhere-deploy-ssh@v1
+        uses: MiguelRizzi/pythonanywhere-deploy-ssh@v1.0.0
         with:
-          username: ${{ secrets.PA_USERNAME }}
-          password: ${{ secrets.PA_PASSWORD }}
-          working_directory: ${{ secrets.PA_WORKING_DIRECTORY }}
-          venv_directory: ${{ secrets.PA_VENV_DIRECTORY }}
-          wsgi_file: /var/www/webapp_name_wsgi.py
+          ssh_host: ssh.eu.pythonanywhere.com # Optional - defaults to ssh.pythonanywhere.com
+          username: ${{ secrets.PA_USERNAME }} # Your PythonAnywhere username
+          password: ${{ secrets.PA_PASSWORD }} # Your PythonAnywhere password
+          working_directory: ${{ secrets.PA_WORKING_DIRECTORY }} # Target working directory on PythonAnywhere
+          venv_directory: ${{ secrets.PA_VENV_DIRECTORY }} # Path to your virtual environment
+          wsgi_file: /var/www/webapp_name_wsgi.py # Path to your WSGI file

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Redeploy to PythonAnywhere
-        uses: MiguelRizzi/pythonanywhere-deploy-ssh@v1
+        uses: MiguelRizzi/pythonanywhere-deploy-ssh@v1.0.0
         with:
+          ssh_host: ssh.eu.pythonanywhere.com # Optional - defaults to ssh.pythonanywhere.com
           username: ${{ secrets.PA_USERNAME }}
           password: ${{ secrets.PA_PASSWORD }}
           working_directory: ${{ secrets.PA_WORKING_DIRECTORY }}
@@ -47,11 +48,12 @@ jobs:
 
 | Name      | Description | Required | Example |
 |-----------|-------------|----------|---------|
-| username  | Your PythonAnywhere username | ✅ | miguelrizzi |
-| password  | Your PythonAnywhere password | ✅ | password |
-| working_directory  | Target working directory on PythonAnywhere | ✅ | /home/username/webapp_name |
-| venv_directory  | Path to the Python virtual environment | ✅ | /home/username/webapp_name/.venv |
-| wsgi_file | Path to the WSGI file to reload the app | ✅ | /var/www/webapp_name_wsgi.py |
+| ssh_host  | Optional SSH host for PythonAnywhere (default: ssh.pythonanywhere.com) | No | ssh.eu.pythonanywhere.com |
+| username  | Your PythonAnywhere username | Yes | miguelrizzi |
+| password  | Your PythonAnywhere password | Yes | password |
+| working_directory  | Target working directory on PythonAnywhere | Yes | /home/username/webapp_name |
+| venv_directory  | Path to the Python virtual environment | Yes | /home/username/webapp_name/.venv |
+| wsgi_file | Path to the WSGI file to reload the app | Yes | /var/www/webapp_name_wsgi.py |
 
 
 ## 🔐 Security

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ branding:
   color: blue
 
 inputs:
+  ssh_host:
+    description: "SSH host for PythonAnywhere (default: ssh.pythonanywhere.com)"
+    required: false
+    default: "ssh.pythonanywhere.com"
   username:
     description: "Your PythonAnywhere username"
     required: true
@@ -27,6 +31,7 @@ runs:
   using: docker
   image: Dockerfile
   args:
+    - ${{ inputs.ssh_host }}
     - ${{ inputs.username }}
     - ${{ inputs.password }}
     - ${{ inputs.working_directory }}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 set -e
 
-USERNAME=$1
-PASSWORD=$2
-WORKING_DIRECTORY=$3
-VENV_DIRECTORY=$4
-WSGI_FILE=$5
+SSH_HOST=$1
+USERNAME=$2
+PASSWORD=$3
+WORKING_DIRECTORY=$4
+VENV_DIRECTORY=$5
+WSGI_FILE=$6
 
 echo "Connecting to PythonAnywhere server..."
 
-sshpass -p "$PASSWORD" ssh -o StrictHostKeyChecking=no "$USERNAME@ssh.pythonanywhere.com" << EOF
+sshpass -p "$PASSWORD" ssh -o StrictHostKeyChecking=no "$USERNAME@$SSH_HOST" << EOF
   echo "Changing to working directory..."
   cd "$WORKING_DIRECTORY"
   echo "Activating virtual environment..."


### PR DESCRIPTION
This PR introduces a new input parameter ssh_host to the GitHub Action, allowing users to specify a custom SSH host. 
If no value is provided, the action defaults to using ssh.pythonanywhere.com.

This feature is particularly useful for users with PythonAnywhere accounts hosted in the EU, who need to connect via ssh.eu.pythonanywhere.com. 